### PR TITLE
Flexibility on length of timesteps

### DIFF
--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -345,7 +345,12 @@ class XarrayProvider(BaseProvider):
 
         if self.time_field is not None:
             cj['domain']['axes']['t'] = {
-                'values': [str(v) for v in data[self.time_field].values]
+                'values': [str(v) for v in (
+                    [data[self.time_field].values]
+                    if np.isscalar(data[self.time_field].values)
+                    else data[self.time_field].values
+                    )
+                ]
             }
             cj['domain']['referencing'].append({
                 'coordinates': ['t'],

--- a/pygeoapi/provider/xarray_.py
+++ b/pygeoapi/provider/xarray_.py
@@ -346,9 +346,9 @@ class XarrayProvider(BaseProvider):
         if self.time_field is not None:
             cj['domain']['axes']['t'] = {
                 'values': [str(v) for v in (
-                    [data[self.time_field].values]
-                    if np.isscalar(data[self.time_field].values)
-                    else data[self.time_field].values
+                    data[self.time_field].values
+                    if hasattr(data[self.time_field].values, '__iter__')
+                    else [data[self.time_field].values]
                     )
                 ]
             }


### PR DESCRIPTION
Updated code threw an error when only one timestep was pulled, since it was not possible to iterate over a single `numpy.datetime64` 

This code just checks if the selected data's time field is iterable or not. If it is not, it will turn it into a list. 

